### PR TITLE
don't add the node to the layer, but the layer to the node

### DIFF
--- a/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/paula/PAULA2SaltMapper.java
+++ b/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/paula/PAULA2SaltMapper.java
@@ -247,7 +247,7 @@ public class PAULA2SaltMapper extends PepperMapperImpl {
 		}// create new layer if not exists
 
 		// add sNode to sLayer
-		retVal.getSNodes().add(sNode);
+		sNode.getSLayers().add(retVal);
 
 		return (retVal);
 	}
@@ -279,7 +279,7 @@ public class PAULA2SaltMapper extends PepperMapperImpl {
 		}// create new layer if not exists
 
 		// add sNode to sLayer
-		retVal.getSRelations().add(sRel);
+		sRel.getSLayers().add(retVal);
 
 		return (retVal);
 	}


### PR DESCRIPTION
Since EMF will checck for uniqueness when adding to this list it is faster to add the layer to the node since the node has very few layers but a layer might have tousands of nodes.
