### PR TITLE
Check if target folder already exists

### DIFF
--- a/src/main/java/org/corpus_tools/peppermodules/paula/PAULAExporter.java
+++ b/src/main/java/org/corpus_tools/peppermodules/paula/PAULAExporter.java
@@ -104,11 +104,16 @@ public class PAULAExporter extends PepperExporterImpl implements PepperExporter 
 				resourceURI = resourceURI.appendSegment(segment);
 			}
 			
-			if (!((new File(resourceURI.toFileString())).mkdirs())) {
-				throw new PepperModuleException("Cannot create directory " + resourceURI.toFileString());
-			} else {
-				getIdentifier2ResourceTable().put(sCorpus.getIdentifier(), resourceURI);
-			}
+			
+                            
+                            File folder = new File(resourceURI.toFileString());
+                            if (!folder.exists()) {
+                                if (!(folder.mkdirs())) {
+                                        throw new PepperModuleException("Cannot create directory " + resourceURI.toFileString());
+                                }
+                            } 
+
+                            getIdentifier2ResourceTable().put(sCorpus.getIdentifier(), resourceURI);		
 		}
 		
 		List<SDocument> sDocumentList = Collections.synchronizedList(sCorpusGraph.getDocuments());


### PR DESCRIPTION
  * Prevents crash if merged corpus attempts to write to already existing output folder
  * Fixes korpling/pepperModules-PAULAModules#13